### PR TITLE
Bug fix, optimized path, and additional feature.

### DIFF
--- a/condastats/cli.py
+++ b/condastats/cli.py
@@ -88,12 +88,12 @@ def overall(
     # if monthly, return monthly counts
     if monthly:
         monthly_counts = (
-            df.groupby(["pkg_name", "time"]).sum()
+            df.groupby(["pkg_name", "time"]).counts.sum()
         )
         return monthly_counts
     # return sum of all counts
     else:
-        total_counts = (df.groupby("pkg_name").sum())
+        total_counts = (df.groupby("pkg_name").counts.sum())
         return total_counts
 
 
@@ -145,10 +145,10 @@ def _groupby(package, column, month, start_month, end_month, monthly):
 
     # if monthly, return monthly counts
     if monthly:
-        agg = df.groupby(["pkg_name", "time", column]).sum()
+        agg = df.groupby(["pkg_name", "time", column]).counts.sum()
     # return sum of all counts
     else:
-        agg = df.groupby(["pkg_name", column]).sum()
+        agg = df.groupby(["pkg_name", column]).counts.sum()
 
     return agg
 

--- a/condastats/cli.py
+++ b/condastats/cli.py
@@ -6,38 +6,61 @@ import dask.dataframe as dd
 import pandas as pd
 from datetime import datetime
 import argparse
-pd.set_option('display.max_rows', None)
 
-def overall(package, month=None, start_month=None, end_month=None, monthly=False, pkg_platform=None, data_source=None, pkg_version=None, pkg_python=None):
+pd.set_option("display.max_rows", None)
+
+
+def overall(
+    package,
+    month=None,
+    start_month=None,
+    end_month=None,
+    monthly=False,
+    pkg_platform=None,
+    data_source=None,
+    pkg_version=None,
+    pkg_python=None,
+):
 
     # so we can pass in one or more packages
-    # if more than one packages, e.g., ("pandas","dask") as a tuple or ["pandas","dask"] as a list, 
-    # we need to them with "," so that in f-string it can read correctly as pkg_name in ("pandas","dask")
-    if isinstance(package, tuple) or isinstance(package, list) :
-        package= '","'.join(package)
+    # if more than one packages, e.g., ("pandas","dask") as a tuple or
+    # ["pandas","dask"] as a list,we need to them with "," so that in
+    # f-string it can read correctly as pkg_name in ("pandas","dask")
+    if isinstance(package, tuple) or isinstance(package, list):
+        package = '","'.join(package)
 
-    # if given year-month, read in data for this year-month for this package 
-    if month is not None: 
-        # if month is string, we change the type to datetime. 
+    # if given year-month, read in data for this year-month for this package
+    if month is not None:
+        # if month is string, we change the type to datetime.
         if isinstance(month, str):
-            month = datetime.strptime(month, '%Y-%m')
-        df = dd.read_parquet(f's3://anaconda-package-data/conda/monthly/{month.year}/{month.year}-{month.strftime("%m")}.parquet',
-                         storage_options={'anon': True})
-        df = df.query(f'pkg_name in ("{package}")')        
-    
-    # if given start_month and end_month, read in data between start_month and end_month
-    elif start_month is not None and end_month is not None:
-        #read in month between start_month and end_month
-        file_list = []
-        for month_i in pd.period_range(start_month, end_month, freq='M'):      
-            file_list.append(f's3://anaconda-package-data/conda/monthly/{month_i.year}/{month_i}.parquet')
-        df = dd.read_parquet(file_list,storage_options={'anon': True})
+            month = datetime.strptime(month, "%Y-%m")
+        df = dd.read_parquet(
+            f's3://anaconda-package-data/conda/monthly/{month.year}/{month.year}-{month.strftime("%m")}.parquet',
+            storage_options={"anon": True},
+        )
         df = df.query(f'pkg_name in ("{package}")')
 
-    # if all optional arguments are None, read in all the data for a certain package
+    # if given start_month and end_month, read in data
+    # between start_month and end_month
+    elif start_month is not None and end_month is not None:
+        # read in month between start_month and end_month
+        file_list = []
+        for month_i in pd.period_range(start_month, end_month, freq="M"):
+            file_list.append(
+                f"s3://anaconda-package-data/conda/monthly/{month_i.year}/{month_i}.parquet"
+            )
+        df = dd.read_parquet(file_list, storage_options={"anon": True})
+        df = df.query(f'pkg_name in ("{package}")')
+
+    # if all optional arguments are None, read in all
+    # the data for a certain package
     else:
-        # if all optional arguments are None, read in all the data for a certain package
-        df = dd.read_parquet('s3://anaconda-package-data/conda/monthly/*/*.parquet',storage_options={'anon': True})
+        # if all optional arguments are None, read in
+        # all the data for a certain package
+        df = dd.read_parquet(
+            "s3://anaconda-package-data/conda/monthly/*/*.parquet",
+            storage_options={"anon": True},
+        )
         df = df.query(f'pkg_name in ("{package}")')
 
     # subset data based on other conditions if given
@@ -51,311 +74,350 @@ def overall(package, month=None, start_month=None, end_month=None, monthly=False
     if pkg_python is not None:
         queries.append(f'pkg_python in ("{pkg_python}")')
     if queries:
-        df = df.query(' and '.join(queries))
-    
+        df = df.query(" and ".join(queries))
+
+    df = df.reset_index(drop=True).compute()
+    df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
+
     # if monthly, return monthly counts
     if monthly:
-        monthly_counts = (df.groupby(['pkg_name','time']).counts.sum().compute())
-        return monthly_counts[(monthly_counts!=0)].dropna()
-    # return sum of all counts 
+        monthly_counts = (
+            df.groupby(["pkg_name", "time"]).counts.sum()
+        )
+        return monthly_counts[(monthly_counts != 0)].dropna()
+    # return sum of all counts
     else:
-        total_counts = (df.groupby('pkg_name').counts.sum().compute()).dropna()  
-        return  total_counts[(total_counts!=0)].dropna()
+        total_counts = (df.groupby("pkg_name").counts.sum())
+        return total_counts[(total_counts != 0)].dropna()
 
 
 def _groupby(package, column, month, start_month, end_month, monthly):
-    
-    if isinstance(package, tuple) or isinstance(package, list)  :
-        package= '","'.join(package)
-    # if all optional arguments are None, read in all the data for a certain package    
-    # df = dd.read_parquet(f's3://anaconda-package-data/conda/monthly/*/*.parquet',
-    #                     columns=['time','pkg_name', column, 'counts'],
-    #                     storage_options={'anon': True})
-    # df = df.query(f'pkg_name in ("{package}")')
 
-    # if given year-month, read in data for this year-month for this package 
-    if month is not None: 
+    if isinstance(package, tuple) or isinstance(package, list):
+        package = '","'.join(package)
+
+    # if given year-month, read in data for this year-month for this package
+    if month is not None:
         if isinstance(month, str):
-            month = datetime.strptime(month, '%Y-%m')
-        df = dd.read_parquet(f's3://anaconda-package-data/conda/monthly/{month.year}/{month.year}-{month.strftime("%m")}.parquet',
-                        columns=['time','pkg_name', column, 'counts'],
-                        storage_options={'anon': True})
-
-        print(type(df))
-        print(len(df.index))
-        print()
-
-        df = df.query(f'pkg_name in ("{package}")')        
-
-    # if given start_month and end_month, read in data between start_month and end_month
-    elif start_month is not None and end_month is not None:
-        #read in month between start_month and end_month
-        file_list = []
-        for month_i in pd.period_range(start_month, end_month, freq='M'):      
-            file_list.append(f's3://anaconda-package-data/conda/monthly/{month_i.year}/{month_i}.parquet')
-        df = dd.read_parquet(file_list,columns=['time','pkg_name', column, 'counts'], storage_options={'anon': True})
-        df = df.query(f'pkg_name in ("{package}")') 
-
-    # if all optional arguments are None, read in all the data for a certain package
-    else:
-        df = dd.read_parquet(f's3://anaconda-package-data/conda/monthly/*/*.parquet',
-                        columns=['time','pkg_name', column, 'counts'],
-                        storage_options={'anon': True})
+            month = datetime.strptime(month, "%Y-%m")
+        df = dd.read_parquet(
+            f's3://anaconda-package-data/conda/monthly/{month.year}/{month.year}-{month.strftime("%m")}.parquet',
+            columns=["time", "pkg_name", column, "counts"],
+            storage_options={"anon": True},
+        )
         df = df.query(f'pkg_name in ("{package}")')
 
-    print(df.compute())
-    print(type(df))
-    print(len(df.index))
-    print(df)
-    print()
+    # if given start_month and end_month, read in data
+    # between start_month and end_month
+    elif start_month is not None and end_month is not None:
+        # read in month between start_month and end_month
+        file_list = []
+        for month_i in pd.period_range(start_month, end_month, freq="M"):
+            file_list.append(
+                f"s3://anaconda-package-data/conda/monthly/{month_i.year}/{month_i}.parquet"
+            )
+        df = dd.read_parquet(
+            file_list,
+            columns=["time", "pkg_name", column, "counts"],
+            storage_options={"anon": True},
+        )
+        df = df.query(f'pkg_name in ("{package}")')
 
-    temp = df.compute()
-    print(type(temp))
-    print(len(temp.index))
-    print(temp)
-    print()
+    # if all optional arguments are None, read in all the
+    # data for a certain package
+    else:
+        df = dd.read_parquet(
+            f"s3://anaconda-package-data/conda/monthly/*/*.parquet",
+            columns=["time", "pkg_name", column, "counts"],
+            storage_options={"anon": True},
+        )
+        df = df.query(f'pkg_name in ("{package}")')
 
-    # test = df.set_index(column, sorted=False)
-    # print(type(test))
-    # print(len(test.index))
-    # print(test)
-    # print()
-
-    agg = temp.groupby(['pkg_name', 'time', column]).counts.sum()
-
-    print(len(agg.index))
-    exit()
-    # group = df.groupby(['pkg_name',column])
-    # print(df.groupby(['pkg_name',column]).counts.sum().compute())
+    df = df.reset_index(drop=True).compute()
+    df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
 
     # if monthly, return monthly counts
     if monthly:
-        agg = df.groupby(['pkg_name', 'time', column]).counts.sum().compute()
-    # return sum of all counts 
+        agg = df.groupby(["pkg_name", "time", column]).counts.sum()
+    # return sum of all counts
     else:
-        agg = df.groupby(['pkg_name',column]).counts.sum().compute()
-    
-    return agg[(agg!=0)].dropna()
+        agg = df.groupby(["pkg_name", column]).counts.sum()
+
+    return agg[(agg != 0)].dropna()
 
 
-def pkg_platform(package, month=None, start_month=None, end_month=None, monthly=False):
-    return _groupby(package, 'pkg_platform', month, start_month, end_month, monthly)
+def pkg_platform(
+    package, month=None, start_month=None, end_month=None, monthly=False
+):
+    return _groupby(
+        package, "pkg_platform", month, start_month, end_month, monthly
+    )
 
 
-def data_source(package, month=None, start_month=None, end_month=None, monthly=False):
-    return _groupby(package, 'data_source', month, start_month, end_month, monthly)
+def data_source(
+    package, month=None, start_month=None, end_month=None, monthly=False
+):
+    return _groupby(
+        package, "data_source", month, start_month, end_month, monthly
+    )
 
 
-def pkg_version(package, month=None, start_month=None, end_month=None, monthly=False):
-    return _groupby(package, 'pkg_version', month, start_month, end_month, monthly)
+def pkg_version(
+    package, month=None, start_month=None, end_month=None, monthly=False
+):
+    return _groupby(
+        package, "pkg_version", month, start_month, end_month, monthly
+    )
 
 
-def pkg_python(package, month=None, start_month=None, end_month=None, monthly=False):
-    return _groupby(package, 'pkg_python', month, start_month, end_month, monthly)
+def pkg_python(
+    package, month=None, start_month=None, end_month=None, monthly=False
+):
+    return _groupby(
+        package, "pkg_python", month, start_month, end_month, monthly
+    )
 
 
 def main():
     """Console script for condastats."""
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest='subparserdest')
+    subparsers = parser.add_subparsers(dest="subparserdest")
 
-    parser_overall = subparsers.add_parser('overall')
+    parser_overall = subparsers.add_parser("overall")
 
-    parser_overall.add_argument("package",
-                        help="package name(s)",
-                        nargs='+'
-                       )
+    parser_overall.add_argument("package", help="package name(s)", nargs="+")
 
-    parser_overall.add_argument("--month",
-                        help="month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_overall.add_argument(
+        "--month",
+        help="month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_overall.add_argument("--start_month",
-                        help="start month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
- 
-    parser_overall.add_argument("--end_month",
-                        help="end month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_overall.add_argument(
+        "--start_month",
+        help="start month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_overall.add_argument("--monthly",
-                        help="return monthly values (defalt: False)",
-                        action='store_true'
-                       )
+    parser_overall.add_argument(
+        "--end_month",
+        help="end month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_overall.add_argument("--pkg_platform",
-                        help="package platform e.g., win-64, linux-32, osx-64. (defalt: None)",
-                        default=None 
-                       )
-    
-    parser_overall.add_argument("--pkg_python",
-                        help="Python version e.g., 3.7 (defalt: None)",
-                        default=None 
-                       )
-     
-    parser_overall.add_argument("--pkg_version",
-                        help="Python version e.g., 0.1.0 (defalt: None)",
-                        default=None 
-                       )   
-    parser_overall.add_argument("--data_source",
-                        help="Data source e.g., anaconda, conda-forge (defalt: None)",
-                        default=None 
-                       )  
+    parser_overall.add_argument(
+        "--monthly",
+        help="return monthly values (defalt: False)",
+        action="store_true",
+    )
 
-    parser_platform = subparsers.add_parser('pkg_platform')
+    parser_overall.add_argument(
+        "--pkg_platform",
+        help="package platform e.g., win-64, linux-32, osx-64. (defalt: None)",
+        default=None,
+    )
 
-    parser_platform.add_argument("package",
-                        help="package name(s)",
-                        nargs='+'
-                       )
+    parser_overall.add_argument(
+        "--pkg_python",
+        help="Python version e.g., 3.7 (defalt: None)",
+        default=None,
+    )
 
-    parser_platform.add_argument("--month",
-                        help="month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_overall.add_argument(
+        "--pkg_version",
+        help="Python version e.g., 0.1.0 (defalt: None)",
+        default=None,
+    )
+    parser_overall.add_argument(
+        "--data_source",
+        help="Data source e.g., anaconda, conda-forge (defalt: None)",
+        default=None,
+    )
 
-    parser_platform.add_argument("--start_month",
-                        help="start month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
- 
-    parser_platform.add_argument("--end_month",
-                        help="end month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_platform = subparsers.add_parser("pkg_platform")
 
-    parser_platform.add_argument("--monthly",
-                        help="return monthly values (defalt: False)",
-                        action='store_true'
-                       )
+    parser_platform.add_argument("package", help="package name(s)", nargs="+")
 
-    parser_source = subparsers.add_parser('data_source')
+    parser_platform.add_argument(
+        "--month",
+        help="month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_source.add_argument("package",
-                        help="package name(s)",
-                        nargs='+'
-                       )
+    parser_platform.add_argument(
+        "--start_month",
+        help="start month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_source.add_argument("--month",
-                        help="month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
-    parser_source.add_argument("--start_month",
-                        help="start month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
- 
-    parser_source.add_argument("--end_month",
-                        help="end month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_platform.add_argument(
+        "--end_month",
+        help="end month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_source.add_argument("--monthly",
-                        help="return monthly values (defalt: False)",
-                        action='store_true'
-                       )
+    parser_platform.add_argument(
+        "--monthly",
+        help="return monthly values (defalt: False)",
+        action="store_true",
+    )
 
+    parser_source = subparsers.add_parser("data_source")
 
-    parser_package_version = subparsers.add_parser('pkg_version')
+    parser_source.add_argument("package", help="package name(s)", nargs="+")
 
-    parser_package_version.add_argument("package",
-                        help="package name(s)",
-                        nargs='+'
-                       )
+    parser_source.add_argument(
+        "--month",
+        help="month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+    parser_source.add_argument(
+        "--start_month",
+        help="start month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_package_version.add_argument("--month",
-                        help="month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
-    parser_package_version.add_argument("--start_month",
-                        help="start month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
- 
-    parser_package_version.add_argument("--end_month",
-                        help="end month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_source.add_argument(
+        "--end_month",
+        help="end month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_package_version.add_argument("--monthly",
-                        help="return monthly values (defalt: False)",
-                        action='store_true'
-                       )
+    parser_source.add_argument(
+        "--monthly",
+        help="return monthly values (defalt: False)",
+        action="store_true",
+    )
 
-    parser_python_version = subparsers.add_parser('pkg_python')
+    parser_package_version = subparsers.add_parser("pkg_version")
 
-    parser_python_version.add_argument("package",
-                        help="package name(s)",
-                        nargs='+'
-                       )
+    parser_package_version.add_argument(
+        "package", help="package name(s)", nargs="+"
+    )
 
-    parser_python_version.add_argument("--month",
-                        help="month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
-    parser_python_version.add_argument("--start_month",
-                        help="start month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
- 
-    parser_python_version.add_argument("--end_month",
-                        help="end month - YYYY-MM (defalt: None)",
-                        type=lambda d: datetime.strptime(d, '%Y-%m'),
-                        default=None
-                       )
+    parser_package_version.add_argument(
+        "--month",
+        help="month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+    parser_package_version.add_argument(
+        "--start_month",
+        help="start month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
 
-    parser_python_version.add_argument("--monthly",
-                        help="return monthly values (defalt: False)",
-                        action='store_true'
-                       )
+    parser_package_version.add_argument(
+        "--end_month",
+        help="end month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+
+    parser_package_version.add_argument(
+        "--monthly",
+        help="return monthly values (defalt: False)",
+        action="store_true",
+    )
+
+    parser_python_version = subparsers.add_parser("pkg_python")
+
+    parser_python_version.add_argument(
+        "package", help="package name(s)", nargs="+"
+    )
+
+    parser_python_version.add_argument(
+        "--month",
+        help="month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+    parser_python_version.add_argument(
+        "--start_month",
+        help="start month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+
+    parser_python_version.add_argument(
+        "--end_month",
+        help="end month - YYYY-MM (defalt: None)",
+        type=lambda d: datetime.strptime(d, "%Y-%m"),
+        default=None,
+    )
+
+    parser_python_version.add_argument(
+        "--monthly",
+        help="return monthly values (defalt: False)",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
-    if args.subparserdest == 'overall':
-        print(overall(
-            package=args.package,
-            month=args.month, 
-            start_month=args.start_month,
-            end_month = args.end_month,
-            monthly=args.monthly,
-            pkg_platform=args.pkg_platform,
-            data_source=args.data_source,
-            pkg_version=args.pkg_version,
-            pkg_python=args.pkg_python
-            ))
-    elif args.subparserdest == 'pkg_platform':
-        print(pkg_platform(
-            package=args.package, month=args.month, start_month=args.start_month, end_month=args.end_month,monthly=args.monthly
-            ))
-    elif args.subparserdest == 'data_source':
-        print(data_source(
-            package=args.package, month=args.month, start_month=args.start_month, end_month=args.end_month,monthly=args.monthly
-            ))
-    elif args.subparserdest == 'pkg_version':
-        print(pkg_version(
-            package=args.package, month=args.month, start_month=args.start_month, end_month=args.end_month,monthly=args.monthly
-            ))
-    elif args.subparserdest == 'pkg_python':
-        print(pkg_python(
-            package=args.package, month=args.month, start_month=args.start_month, end_month=args.end_month,monthly=args.monthly
-            ))
+    if args.subparserdest == "overall":
+        print(
+            overall(
+                package=args.package,
+                month=args.month,
+                start_month=args.start_month,
+                end_month=args.end_month,
+                monthly=args.monthly,
+                pkg_platform=args.pkg_platform,
+                data_source=args.data_source,
+                pkg_version=args.pkg_version,
+                pkg_python=args.pkg_python,
+            )
+        )
+    elif args.subparserdest == "pkg_platform":
+        print(
+            pkg_platform(
+                package=args.package,
+                month=args.month,
+                start_month=args.start_month,
+                end_month=args.end_month,
+                monthly=args.monthly,
+            )
+        )
+    elif args.subparserdest == "data_source":
+        print(
+            data_source(
+                package=args.package,
+                month=args.month,
+                start_month=args.start_month,
+                end_month=args.end_month,
+                monthly=args.monthly,
+            )
+        )
+    elif args.subparserdest == "pkg_version":
+        print(
+            pkg_version(
+                package=args.package,
+                month=args.month,
+                start_month=args.start_month,
+                end_month=args.end_month,
+                monthly=args.monthly,
+            )
+        )
+    elif args.subparserdest == "pkg_python":
+        print(
+            pkg_python(
+                package=args.package,
+                month=args.month,
+                start_month=args.start_month,
+                end_month=args.end_month,
+                monthly=args.monthly,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/condastats/cli.py
+++ b/condastats/cli.py
@@ -111,9 +111,15 @@ def _groupby(package, column, month, start_month, end_month, monthly):
 
     temp = df.compute()
     print(type(temp))
-    print(len(df.index))
+    print(len(temp.index))
     print(temp)
     print()
+
+    # test = df.set_index(column, sorted=False)
+    # print(type(test))
+    # print(len(test.index))
+    # print(test)
+    # print()
 
     agg = temp.groupby(['pkg_name', 'time', column]).counts.sum()
 

--- a/condastats/cli.py
+++ b/condastats/cli.py
@@ -16,6 +16,7 @@ def overall(
     start_month=None,
     end_month=None,
     monthly=False,
+    complete=False,
     pkg_platform=None,
     data_source=None,
     pkg_version=None,
@@ -62,6 +63,12 @@ def overall(
             storage_options={"anon": True},
         )
         df = df.query(f'pkg_name in ("{package}")')
+
+    # print(df)
+    if complete:
+        df = df.reset_index(drop=True).compute()
+        df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
+        return df
 
     # subset data based on other conditions if given
     queries = []
@@ -211,6 +218,12 @@ def main():
     parser_overall.add_argument(
         "--monthly",
         help="return monthly values (defalt: False)",
+        action="store_true",
+    )
+
+    parser_overall.add_argument(
+        "--complete",
+        help="return all values (defalt: False)",
         action="store_true",
     )
 
@@ -369,6 +382,7 @@ def main():
             overall(
                 package=args.package,
                 month=args.month,
+                complete=args.complete,
                 start_month=args.start_month,
                 end_month=args.end_month,
                 monthly=args.monthly,

--- a/condastats/cli.py
+++ b/condastats/cli.py
@@ -64,9 +64,8 @@ def overall(
         )
         df = df.query(f'pkg_name in ("{package}")')
 
-    # print(df)
     if complete:
-        df = df.reset_index(drop=True).compute()
+        df = df.compute()
         df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
         return df
 
@@ -83,19 +82,19 @@ def overall(
     if queries:
         df = df.query(" and ".join(queries))
 
-    df = df.reset_index(drop=True).compute()
+    df = df.compute()
     df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
 
     # if monthly, return monthly counts
     if monthly:
         monthly_counts = (
-            df.groupby(["pkg_name", "time"]).counts.sum()
+            df.groupby(["pkg_name", "time"]).sum()
         )
-        return monthly_counts[(monthly_counts != 0)].dropna()
+        return monthly_counts
     # return sum of all counts
     else:
-        total_counts = (df.groupby("pkg_name").counts.sum())
-        return total_counts[(total_counts != 0)].dropna()
+        total_counts = (df.groupby("pkg_name").sum())
+        return total_counts
 
 
 def _groupby(package, column, month, start_month, end_month, monthly):
@@ -140,17 +139,18 @@ def _groupby(package, column, month, start_month, end_month, monthly):
         )
         df = df.query(f'pkg_name in ("{package}")')
 
-    df = df.reset_index(drop=True).compute()
+    df = df.compute()
     df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
+    df[column] = df[column].cat.remove_unused_categories()
 
     # if monthly, return monthly counts
     if monthly:
-        agg = df.groupby(["pkg_name", "time", column]).counts.sum()
+        agg = df.groupby(["pkg_name", "time", column]).sum()
     # return sum of all counts
     else:
-        agg = df.groupby(["pkg_name", column]).counts.sum()
+        agg = df.groupby(["pkg_name", column]).sum()
 
-    return agg[(agg != 0)].dropna()
+    return agg
 
 
 def pkg_platform(


### PR DESCRIPTION
Closes #2 

This PR does the following
1. Bug Fix
If a user pass `--pkg_version=xxxx`, an excessive amount of memory would be used search empty categories.

Added the following
```python
df = df.reset_index(drop=True).compute()
df["pkg_name"] = df["pkg_name"].cat.remove_unused_categories()
```

2. Optimized path
In original code, all parquet files would be loaded first, then if `--month` was passed a single parquet would be loaded overwriting the previous.

Moved "load all" to after `--month` and `--start_month`.

Original speed
```bash
(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --month=2021-02
pkg_name
cutensor    4807
Name: counts, dtype: int64

real    0m11.174s
user    0m2.124s
sys     0m1.019s

(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --start_month=2021-01 --end_month=2021-02
pkg_name
cutensor    6168
Name: counts, dtype: int64

real    0m14.940s
user    0m3.543s
sys     0m1.127s
```

Updated
```bash
(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --month=2021-02
pkg_name
cutensor    4807
Name: counts, dtype: int64

real    0m2.095s
user    0m1.683s
sys     0m1.076s

(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --start_month=2021-01 --end_month=2021-02
pkg_name
cutensor    6168
Name: counts, dtype: int64

real    0m2.627s
user    0m1.804s
sys     0m1.118s
```

3. Added `--complete` to export all stats
This will allow users to get all important data without having to rerun multiple times.

Example
```bash
(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --complete
      time  data_source  pkg_name pkg_version pkg_platform pkg_python  counts  dir0
0  2021-01  conda-forge  cutensor     1.2.2.5     linux-64               1092  2021
1  2021-01  conda-forge  cutensor     1.2.2.5       win-64                269  2021
0  2021-02  conda-forge  cutensor     1.2.2.5     linux-64               4433  2021
1  2021-02  conda-forge  cutensor     1.2.2.5       win-64                374  2021

real    0m15.201s
user    0m6.278s
sys     0m1.723s
(base) belt@orion:~/workStuff/git_examples/condastats$ time python3 condastats/cli.py overall cutensor --month=2021-02 --complete
      time  data_source  pkg_name pkg_version pkg_platform pkg_python  counts
0  2021-02  conda-forge  cutensor     1.2.2.5     linux-64               4433
1  2021-02  conda-forge  cutensor     1.2.2.5       win-64                374

real    0m2.103s
user    0m1.632s
sys     0m1.037s
```

Shoutout to @mtjrider for all his help!